### PR TITLE
#37: new basic_model and effectiveTime is not filtered

### DIFF
--- a/config/basic_model.xmi
+++ b/config/basic_model.xmi
@@ -138,12 +138,12 @@
                    <modelingAuthorities>steg</modelingAuthorities>
                    <modelingAuthorities>one</modelingAuthorities>
                    <modelingAuthorities>fskees</modelingAuthorities>
-                   <synchronousAreas>EU</synchronousAreas>
-                   <synchronousAreas>CE</synchronousAreas>
-                   <synchronousAreas>BA</synchronousAreas>
-                   <synchronousAreas>NO</synchronousAreas>
-                   <synchronousAreas>IN</synchronousAreas>
-                   <synchronousAreas>UK</synchronousAreas>
+                   <cgmRegions>EU</cgmRegions>
+                   <cgmRegions>CE</cgmRegions>
+                   <cgmRegions>BA</cgmRegions>
+                   <cgmRegions>NO</cgmRegions>
+                   <cgmRegions>IN</cgmRegions>
+                   <cgmRegions>UK</cgmRegions>
                    <mas>http://www.baltic-rsc.eu/OperationalPlanning</mas>
                    <mas>http://www.coreso.eu/OperationalPlanning</mas>
                    <mas>http://www.entsoe.eu/OperationalPlanning</mas>

--- a/src/main/java/ocl/service/TransformationService.java
+++ b/src/main/java/ocl/service/TransformationService.java
@@ -1041,7 +1041,8 @@ public class TransformationService extends BasicService implements Transformatio
                         if(childs.item(c).getLocalName()!=null){
                             String localName= childs.item(c).getLocalName();
                             if(localName.contains("Model.scenarioTime")){
-                                effectiveDate = childs.item(c).getTextContent().replaceAll("[:.-]","");
+                                effectiveDate = childs.item(c).getTextContent();
+                                // ".replaceAll("[:.-]","")" was deleted because we had this error reported in validation: Value '20201026T000000000Z' is not
                             }
                             if(localName.contains("Model.modelingAuthoritySet")){
                                 Pattern pattern = Pattern.compile("\\:\\/\\/(.*)\\..*\\/");

--- a/src/main/java/ocl/service/TransformationService.java
+++ b/src/main/java/ocl/service/TransformationService.java
@@ -1042,7 +1042,7 @@ public class TransformationService extends BasicService implements Transformatio
                             String localName= childs.item(c).getLocalName();
                             if(localName.contains("Model.scenarioTime")){
                                 effectiveDate = childs.item(c).getTextContent();
-                                // ".replaceAll("[:.-]","")" was deleted because we had this error reported in validation: Value '20201026T000000000Z' is not
+                                // ".replaceAll("[:.-]","")" was deleted because we had this error reported in validation: Value '20201026T000000000Z' is not legal
                             }
                             if(localName.contains("Model.modelingAuthoritySet")){
                                 Pattern pattern = Pattern.compile("\\:\\/\\/(.*)\\..*\\/");


### PR DESCRIPTION
small modif in basic_model and correction in addFullModelInfo in order to prevent this error:

2021-02-18 09:42:59] [GRAVE  ] Problem with: urn:uuid:325111ba-13db-4936-b624-513693da35b1 (value:20201026T000000000Z)
[2021-02-18 09:42:59] [GRAVE  ] Value '20201026T000000000Z' is not legal. (file:///home/herguetaortegamar/Documents/8_OCLValidator/cgmes-ocl-validator/target/ocl_validator-3.0-bin/ocl_validator-3.0/d8e98ef0-2b46-4c51-bb30-7265cc53e260, 272, 530)
 org.eclipse.emf.ecore.xmi.impl.XMLHandler.setFeatureValue(XMLHandler.java:2715)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.setAttribValue(XMLHandler.java:2769)
    at org.eclipse.emf.ecore.xmi.impl.SAXXMIHandler.handleObjectAttribs(SAXXMIHandler.java:79)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.createObjectFromFactory(XMLHandler.java:2247)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.createObjectFromTypeName(XMLHandler.java:2150)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.createObject(XMLHandler.java:2085)
    at org.eclipse.emf.ecore.xmi.impl.XMIHandler.createObject(XMIHandler.java:151)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.handleFeature(XMLHandler.java:1894)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.processElement(XMLHandler.java:1048)
    at org.eclipse.emf.ecore.xmi.impl.XMIHandler.processElement(XMIHandler.java:82)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.startElement(XMLHandler.java:1026)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.startElement(XMLHandler.java:720)
    at org.eclipse.emf.ecore.xmi.impl.XMIHandler.startElement(XMIHandler.java:190)
    at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.startElement(AbstractSAXParser.java:509)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanStartElement(XMLDocumentFragmentScannerImpl.java:1359)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl$FragmentContentDriver.next(XMLDocumentFragmentScannerImpl.java:2784)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentScannerImpl.next(XMLDocumentScannerImpl.java:602)
    at com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl.scanDocument(XMLDocumentFragmentScannerImpl.java:505)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:842)
    at com.sun.org.apache.xerces.internal.parsers.XML11Configuration.parse(XML11Configuration.java:771)
    at com.sun.org.apache.xerces.internal.parsers.XMLParser.parse(XMLParser.java:141)
    at com.sun.org.apache.xerces.internal.parsers.AbstractSAXParser.parse(AbstractSAXParser.java:1213)
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl$JAXPSAXParser.parse(SAXParserImpl.java:643)
    at com.sun.org.apache.xerces.internal.jaxp.SAXParserImpl.parse(SAXParserImpl.java:327)
    at org.eclipse.emf.ecore.xmi.impl.XMLLoadImpl.load(XMLLoadImpl.java:175)
    at org.eclipse.emf.ecore.xmi.impl.XMLResourceImpl.doLoad(XMLResourceImpl.java:261)
    at org.eclipse.emf.ecore.resource.impl.ResourceImpl.load(ResourceImpl.java:1563)
    at ocl.service.ValidationService.evaluate(ValidationService.java:144)
    at ocl.Validation.main(Validation.java:53)
Caused by: org.eclipse.emf.common.util.WrappedException: java.text.ParseException: Unparseable date: "20201026T000000Z"
    at org.eclipse.emf.ecore.impl.EcoreFactoryImpl.createEDateFromString(EcoreFactoryImpl.java:446)
    at org.eclipse.emf.ecore.impl.EcoreFactoryImpl.createFromString(EcoreFactoryImpl.java:132)
    at org.eclipse.emf.ecore.xmi.impl.XMLHelperImpl.createFromString(XMLHelperImpl.java:1615)
    at org.eclipse.emf.ecore.xmi.impl.XMLHelperImpl.setValue(XMLHelperImpl.java:1156)
    at org.eclipse.emf.ecore.xmi.impl.XMLHandler.setFeatureValue(XMLHandler.java:2710)
    ... 28 more
Caused by: java.text.ParseException: Unparseable date: "2020\10\26T00\00\00Z"
    at java.text.DateFormat.parse(DateFormat.java:366)
    at org.eclipse.emf.ecore.impl.EFactoryImpl$SafeSimpleDateFormat.parse(EFactoryImpl.java:781)
    at org.eclipse.emf.ecore.impl.EcoreFactoryImpl.createEDateFromString(EcoreFactoryImpl.java:439)
    ... 32 more